### PR TITLE
fix braces in comments breaking split

### DIFF
--- a/src/commands/split.js
+++ b/src/commands/split.js
@@ -72,6 +72,9 @@ module.exports = {
           // Add current line to current contract.
           line = line.replace(/\r?\n|\r/, ''); // Remove line breaks from line.
           contracts[currentContractIdx] += `${line}\n`;
+          
+          // Skip commented curlies
+          if(['*','/*','//'].some(reg => line.trim().startsWith(reg))) continue
 
           // Count curly braces.
           const openCurlies = line.match(/{/g);


### PR DESCRIPTION
In newer versions of the OpenZeppelin contracts, it's commonplace to include curly braces in comments ([example](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/56de324afea13c4649b00ca8c3a3e3535d532bd4/contracts/token/ERC20/IERC20.sol#L24)), this breaks the `split` command.

Added a quick fix to ignore common cases (//, \*, /\*), although it will still break if it's in a comment block without a preceding asterisk.   

Thanks for the awesome tool ♥️