### PR TITLE
Bump web3 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "solc": "^0.5.8",
     "tmp": "^0.1.0",
     "treeify": "^1.1.0",
-    "web3": "1.0.0-beta.37"
+    "web3": "^1.5.3"
   },
   "devDependencies": {
     "ganache-cli": "^6.4.3",


### PR DESCRIPTION
I'm interested in a tool like this and happy to help fix some of the stale tests (`user project is inactive`) if the project is still useful.

Given how fast the space moves I understand if you're using another set of tools. Could you point me towards those if you are. 